### PR TITLE
Added support for power usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ Supported platforms: Linux (required tools: `sysfs`), FreeBSD (required tools:
   * FreeBSD: takes optional battery ID as an argument, i.e. `"batt"` or `"0"`
 - Returns (per platform):
   * Linux: returns 1st value as state of requested battery, 2nd as charge
-    level in percent, 3rd as remaining (charging or discharging) time and 4th
-    as the wear level in percent
-  * FreeBSD: see Linux, but there's is 5th value for the present dis-/charge
+    level in percent, 3rd as remaining (charging or discharging) time, 4th
+    as the wear level in percent and 5th value for the present dis-/charge 
     rate in Watt.
+  * FreeBSD: see Linux 
 
 **vicious.widgets.cpu**
 

--- a/contrib/net_linux.lua
+++ b/contrib/net_linux.lua
@@ -89,7 +89,7 @@ local function worker(format, tignorelist)
                     ccarrier = tonumber(sysnet.carrier)
 
                     args["{"..name.." carrier}"] = ccarrier
-                    if ccarrier ~= 0 and not tignore[name] then
+                    if ccarrier == 1 and not tignore[name] then
                         any_up = 1
                     end
                 else

--- a/widgets/bat_linux.lua
+++ b/widgets/bat_linux.lua
@@ -34,9 +34,15 @@ local function worker(format, warg)
         ["Discharging\n"] = "−"
     }
 
+    -- Get current power usage in watt
+    local curpower = "N/A"
+    if battery.power_now then
+        curpower = string.format("%.2f", tonumber(battery.power_now) /1000000)
+    end
+
     -- Check if the battery is present
     if battery.present ~= "1\n" then
-        return {battery_state["Unknown\n"], 0, "N/A", 0}
+        return {battery_state["Unknown\n"], 0, "N/A", 0, curpower}
     end
 
 
@@ -51,7 +57,7 @@ local function worker(format, warg)
         remaining, capacity = battery.energy_now, battery.energy_full
         capacity_design = battery.energy_full_design or capacity
     else
-        return {battery_state["Unknown\n"], 0, "N/A", 0}
+        return {battery_state["Unknown\n"], 0, "N/A", 0, curpower}
     end
 
     -- Calculate capacity and wear percentage (but work around broken BAT/ACPI implementations)
@@ -65,7 +71,7 @@ local function worker(format, warg)
     elseif battery.power_now then
         rate = tonumber(battery.power_now)
     else
-        return {state, percent, "N/A", wear}
+        return {state, percent, "N/A", wear, curpower}
     end
 
     -- Calculate remaining (charging or discharging) time
@@ -77,7 +83,7 @@ local function worker(format, warg)
         elseif state == "−" then
             timeleft = tonumber(remaining) / tonumber(rate)
         else
-            return {state, percent, time, wear}
+            return {state, percent, time, wear, curpower}
         end
 
         -- Calculate time
@@ -87,7 +93,7 @@ local function worker(format, warg)
         time = string.format("%02d:%02d", hoursleft, minutesleft)
     end
 
-    return {state, percent, time, wear}
+    return {state, percent, time, wear, curpower}
 end
 -- }}}
 


### PR DESCRIPTION
Reads power usage for hardware that supports it.
Returns the value in watts with two decimal digits as the fifth element of the returned array.

See the rightmost value in this image:
![image](https://cloud.githubusercontent.com/assets/1256049/22222742/431ed56e-e1b8-11e6-920b-e01558a15681.png)

