### PR TITLE
Minimal change to allow asynchronous call (for Awesome4+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,9 +395,11 @@ Supported platforms: platform independent.
 
 - Arguments:
   * Takes the Linux or BSD distribution name as an argument, i.e. `"Arch"`,
-    `"FreeBSD"`
+    `"Arch C"`, `"Arch S"`, `"Debian"`, `"Ubuntu"`, `"Fedora"`, `"FreeBSD"`,
+    `"Mandriva"`
 - Returns:
-  * Returns 1st value as the count of available updates
+  * Returns 1st value as the count of available updates, 2nd as the list of
+    packages to update
 
 **vicious.widgets.raid**
 

--- a/widgets/pkg_all.lua
+++ b/widgets/pkg_all.lua
@@ -32,12 +32,9 @@ function pkg_all.async(warg, callback)
         ["Mandriva"]={ cmd = "urpmq --auto-select" }
     }
 
-    -- Select command
-    local _pkg = manager[warg]
-
     -- Check if updates are available
-    local function parse(str)
-        local size, lines, first = 0, "", _pkg.sub or 0
+    local function parse(str, skiprows)
+        local size, lines, first = 0, "", skiprows or 0
         for line in str:gmatch("[^\r\n]+") do
             if size >= first then
                 lines = lines .. (size == first and "" or "\n") .. line
@@ -48,7 +45,9 @@ function pkg_all.async(warg, callback)
         return {size, lines}
     end
     
-    spawn.easy_async(_pkg.cmd, function(stdout) callback(parse(stdout)) end)
+    -- Select command
+    local _pkg = manager[warg]
+    spawn.easy_async(_pkg.cmd, function(stdout) callback(parse(stdout, _pkg.sub)) end)
 end
 -- }}}
 

--- a/widgets/pkg_all.lua
+++ b/widgets/pkg_all.lua
@@ -37,12 +37,17 @@ local function worker(format, warg)
     local _pkg = manager[warg]
     local f = io.popen(_pkg.cmd)
 
+    local size, lines, first = 0, "", _pkg.sub or 0
     for line in f:lines() do
-        updates = updates + 1
+        if size >= first then
+            lines = lines .. (size == first and "" or "\n") .. line
+        end
+        size = size + 1
     end
+    size = math.max(size-first, 0)
     f:close()
 
-    return {_pkg.sub and math.max(updates-_pkg.sub, 0) or updates}
+    return {size, lines}
 end
 -- }}}
 


### PR DESCRIPTION
If a `[widget].async` function is defined, it is called instead of the synchronous `worker` function. It works only for awesome>4.0 as it uses `awful.spawn.easy_asunc`. It takes two arguments, `warg` and a `callback` function that updates the widget.

Only applied with one example, `pkg`.

I also added another value to the table output of `pkg`, the list of packages.

By the way, the first argument `format` of the `worker` functions is never used, except for the `date` widget. Maybe it would be good to remove it to simplify the code.
