### PR TITLE
Use wibox for battery widget example

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,17 +628,27 @@ argument
 
 **Battery widget**
 
-```Lua
-    batwidget = awful.widget.progressbar()
-    batwidget:set_width(8)
-    batwidget:set_height(10)
-    batwidget:set_vertical(true)
-    batwidget:set_background_color("#494B4F")
-    batwidget:set_border_color(nil)
+```lua
+    batwidget = wibox.widget.progressbar()
+    batwidget:set_background_color("#FF5656")
     batwidget:set_color("#AECF96")
-    batwidget:set_color({ type = "linear", from = { 0, 0 }, to = { 0, 10 },
-      stops = {{ 0, "#AECF96" }, { 0.5, "#88A175" }, { 1, "#FF5656" }}})
+
+    -- Register battery widget
     vicious.register(batwidget, vicious.widgets.bat, "$2", 61, "BAT0")
+
+    -- Create wibox with batwidget
+    batbox = wibox.widget {
+      {
+        max_value     = 1,
+        widget        = batwidget,
+        border_width  = 0.5,
+        border_color  = "#000000",
+      },
+      forced_height = 10,
+      forced_width  = 8,
+      direction     = 'east',
+      layout        = wibox.container.rotate,
+    }
 ```
 updated every 61 seconds, requests the current battery charge
 level and displays a progressbar, provides "BAT0" battery ID as an

--- a/README.md
+++ b/README.md
@@ -630,11 +630,6 @@ argument
 
 ```lua
     batwidget = wibox.widget.progressbar()
-    batwidget:set_background_color("#FF5656")
-    batwidget:set_color("#AECF96")
-
-    -- Register battery widget
-    vicious.register(batwidget, vicious.widgets.bat, "$2", 61, "BAT0")
 
     -- Create wibox with batwidget
     batbox = wibox.widget {
@@ -643,12 +638,25 @@ argument
         widget        = batwidget,
         border_width  = 0.5,
         border_color  = "#000000",
+        color         = {
+          type = "linear",
+          from = { 0, 0 },
+          to = { 0, 30 },
+          stops = {
+            { 0, "#AECF96" },
+            { 1, "#FF5656" }
+          }
+       }
       },
       forced_height = 10,
       forced_width  = 8,
       direction     = 'east',
+      color         = beautiful.fg_widget,
       layout        = wibox.container.rotate,
     }
+    batbox = wibox.layout.margin(batbox, 1, 1, 3, 3)
+    -- Register battery widget
+    vicious.register(batwidget, vicious.widgets.bat, "$2", 61, "BAT0")
 ```
 updated every 61 seconds, requests the current battery charge
 level and displays a progressbar, provides "BAT0" battery ID as an


### PR DESCRIPTION
Since awesome 4 example batterywidget in an awful.widget.progressbar does not work anymore. (left progressbar in below screenshot) Instead, batterywidget has been added with wibox.widget.progressbar and is then put into an wibox.widget. (progressbar on the right in screenshot) 
![2017-04-01-18 32 36](https://cloud.githubusercontent.com/assets/3862960/24580562/47751a56-170a-11e7-95bb-16ee471f574e.png)

That is how I got battery widget to work again. Correct me if there is a better way to do it.
