### PR TITLE
Change bat widget discharging state char from U+2212 to U+002D

### DIFF
--- a/widgets/bat_linux.lua
+++ b/widgets/bat_linux.lua
@@ -31,7 +31,7 @@ local function worker(format, warg)
         ["Unknown\n"]     = "⌁",
         ["Charged\n"]     = "↯",
         ["Charging\n"]    = "+",
-        ["Discharging\n"] = "−"
+        ["Discharging\n"] = "-"
     }
 
     -- Get current power usage in watt
@@ -80,7 +80,7 @@ local function worker(format, warg)
     if rate ~= nil and rate ~= 0 then
         if state == "+" then
             timeleft = (tonumber(capacity) - tonumber(remaining)) / tonumber(rate)
-        elseif state == "−" then
+        elseif state == "-" then
             timeleft = tonumber(remaining) / tonumber(rate)
         else
             return {state, percent, time, wear, curpower}


### PR DESCRIPTION
Fixes #36 
This avoids using a unicode character that looks just like a hyphen but
isn't, leading to subtle bugs when developers write code that interacts
with the bat_linux widget.