### PR TITLE
Remove format argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -588,7 +588,7 @@ order to actually display them.
 **Date widget**
 
 ```Lua
-    datewidget = widget({ type = "textbox" })
+    datewidget = wibox.widget.textbox()
     vicious.register(datewidget, vicious.widgets.date, "%b %d, %R")
 ```
 
@@ -598,7 +598,7 @@ date sequences as the format string
 **Memory widget**
 
 ```Lua
-    memwidget = widget({ type = "textbox" })
+    memwidget = wibox.widget.textbox()
     vicious.cache(vicious.widgets.mem)
     vicious.register(memwidget, vicious.widgets.mem, "$1 ($2MB/$3MB)", 13)
 ```
@@ -609,7 +609,7 @@ values and enables caching of this widget type
 **HDD temperature widget**
 
 ```Lua
-    hddtempwidget = widget({ type = "textbox" })
+    hddtempwidget = wibox.widget.textbox()
     vicious.register(hddtempwidget, vicious.widgets.hddtemp, "${/dev/sda} °C", 19)
 ```
 
@@ -620,7 +620,7 @@ not provide the port argument so default port is used
 **Mbox widget**
 
 ```Lua
-    mboxwidget = widget({ type = "textbox" })
+    mboxwidget = wibox.widget.textbox()
     vicious.register(mboxwidget, vicious.widgets.mbox, "$1", 5, "/home/user/mail/Inbox")
 ```
 updated every 5 seconds, provides full path to the mbox as an
@@ -694,7 +694,7 @@ widget.
 
 **Example**
 ```Lua
-    mpdwidget = widget({ type = "textbox" })
+    mpdwidget = wibox.widget.textbox()
     vicious.register(mpdwidget, vicious.widgets.mpd,
      function (widget, args)
        if   args["{state}"] == "Stop" then return ""
@@ -708,7 +708,7 @@ seconds (the default interval)
 
 **Example**
 ```Lua
-    uptimewidget = widget({ type = "textbox" })
+    uptimewidget = wibox.widget.textbox()
     vicious.register(uptimewidget, vicious.widgets.uptime,
       function (widget, args)
         return string.format("Uptime: %2dd %02d:%02d ", args[1], args[2], args[3])
@@ -724,7 +724,7 @@ automatically adapted to text width).
 
 **Example**
 ```Lua
-    uptimewidget = widget({ type = "textbox" })
+    uptimewidget = wibox.widget.textbox()
     uptimewidget.width, uptimewidget.align = 50, "right"
     vicious.register(uptimewidget, vicious.widgets.uptime, "$1 $2:$3", 61)
 ```
@@ -738,7 +738,7 @@ it.
 
 **Example**
 ```Lua
-    ctext = widget({ type = "textbox"})
+    ctext = wibox.widget.textbox()
     cgraph = awful.widget.graph()
     cgraph:set_width(100):set_height(20)
     cgraph:set_stack(true):set_max_value(100)

--- a/README.md
+++ b/README.md
@@ -205,8 +205,10 @@ format string - using regular date sequences.
 Supported platforms: platform independent.
 
 - Arguments:
-  * Takes optional time offset, in seconds, as an argument for example to
-    calculate time zone differences, otherwise current time is formatted
+  * Takes (optional) a table as an argument. First value specifies format
+    string (i.e. `{ "%b %d, %R" }`). An additional value may be given as a
+    time offset, in seconds, to calculate time zone differences 
+    (i.e. `{"%b %d, %R", 3600}`).
 - Returns:
   * Returns the output of os.date, formatted by provided sequences
 
@@ -261,7 +263,7 @@ afterwards. BE AWARE THAT MAKING THESE SETTINGS IS A SECURITY RISK!
     if a table, with 1st field as maximum length and 2nd the widget name (i.e.
     "gmailwidget"), scrolling will be used
 - Returns:
-  * Returns a table with string keys: {count} and {subject}
+  * Returns a table with string keys: `{count}` and `{subject}`
 
 **vicious.widgets.hddtemp**
 

--- a/README.md
+++ b/README.md
@@ -395,9 +395,11 @@ Supported platforms: platform independent.
 
 - Arguments:
   * Takes the Linux or BSD distribution name as an argument, i.e. `"Arch"`,
-    `"FreeBSD"`
+    `"Arch C"`, `"Arch S"`, `"Debian"`, `"Ubuntu"`, `"Fedora"`, `"FreeBSD"`,
+    `"Mandriva"`
 - Returns:
-  * Returns 1st value as the count of available updates
+  * Returns 1st value as the count of available updates, 2nd as the list of
+    packages to update
 
 **vicious.widgets.raid**
 

--- a/init.lua
+++ b/init.lua
@@ -92,7 +92,7 @@ local function update(widget, reg, disablecache)
                     end)
             end
         else
-            return update_value(format_data(reg.wtype(nil, reg.warg)), t, c)
+            return update_value(format_data(reg.wtype(reg.warg)), t, c)
         end
     end
 end

--- a/init.lua
+++ b/init.lua
@@ -49,38 +49,52 @@ local function update(widget, reg, disablecache)
     local t = os.time()
     local data = {}
 
-    -- Check for chached output newer than the last update
-    if widget_cache[reg.wtype] ~= nil then
-        local c = widget_cache[reg.wtype]
-
-        if (c.time == nil or c.time <= t-reg.timer) or disablecache then
-            c.time, c.data = t, reg.wtype(reg.format, reg.warg)
+    local function format_data(data)
+        local ret
+        if type(data) == "table" then
+            if type(reg.format) == "string" then
+                ret = helpers.format(reg.format, data)
+            elseif type(reg.format) == "function" then
+                ret = reg.format(widget, data)
+            end
         end
-
-        data = c.data
-    else
-        data = reg.wtype and reg.wtype(reg.format, reg.warg)
+        return ret or data
     end
 
-    if type(data) == "table" then
-        if type(reg.format) == "string" then
-            data = helpers.format(reg.format, data)
-        elseif type(reg.format) == "function" then
-            data = reg.format(widget, data)
+    local function update_value(data, t, cache)
+        if widget.add_value ~= nil then
+            widget:add_value(tonumber(data) and tonumber(data)/100)
+        elseif widget.set_value ~= nil then
+            widget:set_value(tonumber(data) and tonumber(data)/100)
+        elseif widget.set_markup ~= nil then
+            widget:set_markup(data)
+        else
+            widget.text = data
+        end
+        -- Update cache
+        if t and cache then
+            cache.time, cache.data = t, data
         end
     end
-
-    if widget.add_value ~= nil then
-        widget:add_value(tonumber(data) and tonumber(data)/100)
-    elseif widget.set_value ~= nil then
-        widget:set_value(tonumber(data) and tonumber(data)/100)
-    elseif widget.set_markup ~= nil then
-        widget:set_markup(data)
-    else
-        widget.text = data
+    
+    -- Check for cached output newer than the last update
+    local c = widget_cache[reg.wtype]
+    if c and c.time and c.data and t < c.time+reg.timer and not disablecache then
+        return update_value(format_data(c.data))
+    elseif reg.wtype then
+        if reg.wtype.async then
+            if not reg.lock then
+                reg.lock = true
+                return reg.wtype.async(reg.warg, 
+                    function(data)
+                        update_value(format_data(data), t, c)
+                        reg.lock=false
+                    end)
+            end
+        else
+            return update_value(format_data(reg.wtype(nil, reg.warg)), t, c)
+        end
     end
-
-    return data
 end
 -- }}}
 
@@ -147,6 +161,7 @@ function vicious.register(widget, wtype, format, timer, warg)
     local reg = {
         -- Set properties
         wtype  = wtype,
+        lock   = false,
         format = format,
         timer  = timer,
         warg   = warg,

--- a/init.lua
+++ b/init.lua
@@ -277,7 +277,7 @@ end
 
 -- {{{ Get custom widget format data
 function vicious.call(myw, format, warg)
-    local mydata = myw(format, warg)
+    local mydata = myw(warg)
     if type(format) == "string" then
         return helpers.format(format, mydata)
     elseif type(format) == "function" then

--- a/widgets/bat_freebsd.lua
+++ b/widgets/bat_freebsd.lua
@@ -13,7 +13,7 @@ local string = {
 -- }}}
 local bat_freebsd = {}
 
-local function worker(format, warg)
+local function worker(warg)
     local battery = warg or "batt"
     local bat_info = {}
     local f = io.popen("acpiconf -i " .. helpers.shellquote(battery))

--- a/widgets/bat_linux.lua
+++ b/widgets/bat_linux.lua
@@ -22,7 +22,7 @@ local bat_linux = {}
 
 
 -- {{{ Battery widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     local battery = helpers.pathtotable("/sys/class/power_supply/"..warg)

--- a/widgets/cpu_freebsd.lua
+++ b/widgets/cpu_freebsd.lua
@@ -16,7 +16,7 @@ local cpu_total = {}
 local cpu_idle = {}
 
 -- {{{ CPU widget type
-local function worker(format)
+local function worker(warg)
     local cp_times = helpers.sysctl("kern.cp_times")
     local matches = {}
     local tmp_total = {}

--- a/widgets/cpu_linux.lua
+++ b/widgets/cpu_linux.lua
@@ -29,7 +29,7 @@ local cpu_total  = {}
 local cpu_active = {}
 
 -- {{{ CPU widget type
-local function worker(format)
+local function worker(warg)
     local cpu_lines = {}
 
     -- Get CPU stats

--- a/widgets/cpufreq_freebsd.lua
+++ b/widgets/cpufreq_freebsd.lua
@@ -11,7 +11,7 @@ local cpufreq_freebsd = {}
 
 
 -- {{{ CPU frequency widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     -- Default frequency and voltage values

--- a/widgets/cpufreq_linux.lua
+++ b/widgets/cpufreq_linux.lua
@@ -17,7 +17,7 @@ local cpufreq_linux = {}
 
 
 -- {{{ CPU frequency widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     local _cpufreq = helpers.pathtotable("/sys/devices/system/cpu/"..warg.."/cpufreq")

--- a/widgets/cpuinf_linux.lua
+++ b/widgets/cpuinf_linux.lua
@@ -17,7 +17,7 @@ local cpuinf_linux = {}
 
 
 -- {{{ CPU Information widget type
-local function worker(format)
+local function worker(warg)
     local id = nil
 
     local cpu_info = {} -- Get CPU info

--- a/widgets/date_all.lua
+++ b/widgets/date_all.lua
@@ -19,8 +19,12 @@ local date_all = {}
 
 
 -- {{{ Date widget type
-local function worker(format, warg)
-    return os.date(format or nil, warg and os.time()+warg or nil)
+local function worker(warg)
+    if warg then
+        return os.date(warg[1], warg[2] and os.time()+warg[2] or nil)
+    else
+        return os.date()
+    end
 end
 -- }}}
 

--- a/widgets/dio_linux.lua
+++ b/widgets/dio_linux.lua
@@ -30,7 +30,7 @@ local unit = { ["s"] = 1, ["kb"] = 2, ["mb"] = 2048 }
 local time_unit = { ["ms"] = 1, ["s"] = 1000 }
 
 -- {{{ Disk I/O widget type
-local function worker(format)
+local function worker(warg)
     local disk_lines = {}
 
     for line in io.lines("/proc/diskstats") do

--- a/widgets/fanspeed_freebsd.lua
+++ b/widgets/fanspeed_freebsd.lua
@@ -12,7 +12,7 @@ local tonumber = tonumber
 
 local fanspeed_freebsd = {}
 
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     local fanspeed = helpers.sysctl(warg)

--- a/widgets/fs_all.lua
+++ b/widgets/fs_all.lua
@@ -22,7 +22,7 @@ local fs_all = {}
 local unit = { ["mb"] = 1024, ["gb"] = 1024^2 }
 
 -- {{{ Filesystem widget type
-local function worker(format, warg)
+local function worker(warg)
     -- Fallback to listing local filesystems
     if warg then warg = "" else warg = "-l" end
 

--- a/widgets/gmail_all.lua
+++ b/widgets/gmail_all.lua
@@ -37,7 +37,7 @@ local mail = {
 
 
 -- {{{ Gmail widget type
-local function worker(format, warg)
+local function worker(warg)
     -- Get info from the Gmail atom feed
     local f = io.popen("curl --connect-timeout 1 -m 3 -fsn " .. helpers.shellquote(feed))
 

--- a/widgets/hddtemp_linux.lua
+++ b/widgets/hddtemp_linux.lua
@@ -18,7 +18,7 @@ local hddtemp_linux = {}
 
 
 -- {{{ HDD Temperature widget type
-local function worker(format, warg)
+local function worker(warg)
     -- Fallback to default hddtemp port
     if warg == nil then warg = 7634 end
 

--- a/widgets/mbox_all.lua
+++ b/widgets/mbox_all.lua
@@ -21,7 +21,7 @@ local mbox_all = {}
 local subject = "N/A"
 
 -- {{{ Mailbox widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     -- mbox could be huge, get a 30kb chunk from EOF

--- a/widgets/mboxc_all.lua
+++ b/widgets/mboxc_all.lua
@@ -16,7 +16,7 @@ local mboxc_all = {}
 
 
 -- {{{ Mbox count widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     -- Initialize counters

--- a/widgets/mdir_all.lua
+++ b/widgets/mdir_all.lua
@@ -17,7 +17,7 @@ local mdir_all = {}
 
 
 -- {{{ Maildir widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     -- Initialize counters

--- a/widgets/mem_freebsd.lua
+++ b/widgets/mem_freebsd.lua
@@ -11,7 +11,7 @@ local mem_freebsd = {}
 
 
 -- {{{ Memory widget type
-local function worker(format)
+local function worker(warg)
     local pagesize = tonumber(helpers.sysctl("hw.pagesize"))
     local vm_stats = helpers.sysctl_table("vm.stats.vm")
     local _mem = { buf = {}, total = nil }

--- a/widgets/mem_linux.lua
+++ b/widgets/mem_linux.lua
@@ -18,7 +18,7 @@ local mem_linux = {}
 
 
 -- {{{ Memory widget type
-local function worker(format)
+local function worker(warg)
     local _mem = { buf = {}, swp = {} }
 
     -- Get MEM info

--- a/widgets/mpd_all.lua
+++ b/widgets/mpd_all.lua
@@ -18,7 +18,7 @@ local mpd_all = {}
 
 
 -- {{{ MPD widget type
-local function worker(format, warg)
+local function worker(warg)
     local mpd_state  = {
         ["{volume}"] = 0,
         ["{state}"]  = "N/A",

--- a/widgets/net_freebsd.lua
+++ b/widgets/net_freebsd.lua
@@ -21,7 +21,7 @@ local unit = { ["b"] = 1, ["kb"] = 1024,
 }
 
 -- {{{ Net widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     local args = {}

--- a/widgets/net_linux.lua
+++ b/widgets/net_linux.lua
@@ -27,7 +27,7 @@ local unit = { ["b"] = 1, ["kb"] = 1024,
 }
 
 -- {{{ Net widget type
-local function worker(format)
+local function worker(warg)
     local args = {}
 
     -- Get NET stats

--- a/widgets/org_all.lua
+++ b/widgets/org_all.lua
@@ -21,7 +21,7 @@ local org_all = {}
 
 
 -- {{{ OrgMode widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     -- Compute delays

--- a/widgets/os_all.lua
+++ b/widgets/os_all.lua
@@ -24,7 +24,7 @@ local os_all = {}
 
 
 -- {{{ Operating system widget type
-local function worker(format)
+local function worker(warg)
     local system = {
         ["ostype"]    = "N/A",
         ["hostname"]  = "N/A",

--- a/widgets/pkg_all.lua
+++ b/widgets/pkg_all.lua
@@ -52,7 +52,7 @@ end
 -- }}}
 
 -- {{{ Packages widget type
-local function worker(format, warg)
+local function worker(warg)
     local ret = nil
     
     pkg_all.async(warg, function(data) ret = data end)

--- a/widgets/raid_linux.lua
+++ b/widgets/raid_linux.lua
@@ -24,7 +24,7 @@ local raid_linux = {}
 local mddev = {}
 
 -- {{{ RAID widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
     mddev[warg] = {
         ["found"]    = false,

--- a/widgets/thermal_freebsd.lua
+++ b/widgets/thermal_freebsd.lua
@@ -11,7 +11,7 @@ local thermal_freebsd = {}
 
 
 -- {{{ Thermal widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
     if type(warg) ~= "table" then warg = { warg } end
 

--- a/widgets/thermal_linux.lua
+++ b/widgets/thermal_linux.lua
@@ -19,7 +19,7 @@ local thermal_linux = {}
 
 
 -- {{{ Thermal widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     local zone = { -- Known temperature data sources

--- a/widgets/uptime_freebsd.lua
+++ b/widgets/uptime_freebsd.lua
@@ -14,7 +14,7 @@ local uptime_freebsd = {}
 
 
 -- {{{ Uptime widget type
-local function worker(format)
+local function worker(warg)
     local l1, l5, l15 = string.match(helpers.sysctl("vm.loadavg"), "{ ([%d]+%.[%d]+) ([%d]+%.[%d]+) ([%d]+%.[%d]+) }")
     local up_t = os.time() - tonumber(string.match(helpers.sysctl("kern.boottime"), "sec = ([%d]+)"))
 

--- a/widgets/uptime_linux.lua
+++ b/widgets/uptime_linux.lua
@@ -18,7 +18,7 @@ local uptime_linux = {}
 
 
 -- {{{ Uptime widget type
-local function worker(format)
+local function worker(warg)
     local proc = helpers.pathtotable("/proc")
 
     -- Get system uptime

--- a/widgets/volume_freebsd.lua
+++ b/widgets/volume_freebsd.lua
@@ -13,7 +13,7 @@ local volume_freebsd = {}
 
 
 -- {{{ Volume widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     local mixer_state = { "♫", "♩" }

--- a/widgets/volume_linux.lua
+++ b/widgets/volume_linux.lua
@@ -18,7 +18,7 @@ local volume_linux = {}
 
 
 -- {{{ Volume widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     local mixer_state = {

--- a/widgets/weather_all.lua
+++ b/widgets/weather_all.lua
@@ -35,7 +35,7 @@ local _weather = {
 }
 
 -- {{{ Weather widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     -- Get weather forceast by the station ICAO code, from:

--- a/widgets/wifi_linux.lua
+++ b/widgets/wifi_linux.lua
@@ -31,7 +31,7 @@ local iwcpaths = { "/sbin", "/usr/sbin", "/usr/local/sbin", "/usr/bin" }
 
 
 -- {{{ Wireless widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     -- Default values

--- a/widgets/wifiiw_linux.lua
+++ b/widgets/wifiiw_linux.lua
@@ -24,7 +24,7 @@ local wifiiw_linux = {}
 
 
 -- {{{ Wireless widget type
-local function worker(format, warg)
+local function worker(warg)
     if not warg then return end
 
     -- Default values


### PR DESCRIPTION
Hello,
as discussed in #32 it would be nice to remove the format argument as it is most of the time not needed. This is done in this pull request.

The only really change had to be done in date widget. What do you think about these changes? Is there a better way to do this? The change in the date widget breaks the API, it need to be called in `rc.lua` now like that (see also explanation in readme):
```lua
mydate = wibox.widget.textbox()
vicious.register(mydate, vicious.widgets.date, "<span color=\"#ffffff\">$1</span>", 61, { "%b %d, %R" })
```
What about merging this into a new branch and prepare a v4-only version? We could remove the old helper functions and move to the new async function.

Best