### PR TITLE
Add widget for cmus (follow mpd conventions)

### DIFF
--- a/contrib/README.md
+++ b/contrib/README.md
@@ -13,8 +13,10 @@ To use contrib widgets uncomment the line that loads them in
 init.lua. Or you can load them in your rc.lua after you require
 Vicious:
 
-  vicious = require("vicious")
-  vicious.contrib = require("vicious.contrib")
+```lua
+vicious = require("vicious")
+vicious.contrib = require("vicious.contrib")
+```
 
 
 Widget types
@@ -59,6 +61,18 @@ Supported platforms: Linux (required tools: `sysfs`)
 **vicious.contrib.batproc**
 
 **vicious.contrib.countfiles**
+
+**vicious.widgets.cmus**
+
+Provides cmus player information using `cmus-remote`.
+Supported platforms: platform independent.
+
+- Arguments:
+  * Takes a table as an argument, 1st field should be the socket including host
+    (or nil).
+- Returns:
+  * Returns a table with string keys: `{status}`, `{artist}`, `{title}`,
+    `{duration}`, `{file}`,  `{continue}`, `{shuffle}`, `{repeat}`.
 
 **vicious.contrib.dio**
 
@@ -166,6 +180,8 @@ Supported Platforms: platform independent
 
 Usage examples
 ---------------------------------
+
+```lua
 Pulse Audio widget
   vol = wibox.widget.textbox()
   vicious.register(vol, vicious.contrib.pulse, " $1%", 2, "alsa_output.pci-0000_00_1b.0.analog-stereo")
@@ -182,3 +198,4 @@ Buildbot widget
     {builder="tarball-slave", url="http://buildbot.buildbot.net"}
   }
   vicious.register(buildbotwidget, vicious.contrib.buildbot, "$1,", 3600, buildbotwidget_warg)
+```

--- a/contrib/cmus_all.lua
+++ b/contrib/cmus_all.lua
@@ -31,8 +31,13 @@ local function worker(format, warg)
     }
 
     -- Fallback to CMUS defaults
-    local host = warg and (warg.host or warg[1]) or
-		os.getenv("XDG_RUNTIME_DIR") .. "/cmus-socket"
+    local host = warg and (warg.host or warg[1]) or os.getenv("CMUS_SOCKET")
+
+    if not host and os.getenv("XDG_RUNTIME_DIR") then
+        host = os.getenv("XDG_RUNTIME_DIR") .. "/cmus-socket"
+    elseif not host then
+        host = os.getenv("HOME") .. "/.config/cmus/socket"
+    end
 
     -- Get data from CMUS server
     local f = io.popen(string.format("cmus-remote --query --server %s", host))

--- a/contrib/cmus_all.lua
+++ b/contrib/cmus_all.lua
@@ -1,0 +1,69 @@
+-----------------------------------------------------------
+-- Licensed under the GNU General Public License v2
+--  * (c) 2017, JuanKman94 <juan.carlos.menonita@gmail.com>
+-----------------------------------------------------------
+
+-- {{{ Grab environment
+local tonumber = tonumber
+local io = { popen = io.popen }
+local setmetatable = setmetatable
+local string = { gmatch = string.gmatch, format = string.format }
+local helpers = require("vicious.helpers")
+-- }}}
+
+
+-- Cmus: provides CMUS information
+-- vicious.widgets.cmus
+local cmus_all = {}
+
+
+-- {{{ CMUS widget type
+local function worker(format, warg)
+    local cmus_state  = {
+        ["{duration}"]  = 0,
+        ["{file}"] = "N/A",
+        ["{status}"] = "N/A",
+        ["{title}"]  = "N/A",
+        ["{artist}"]  = "N/A",
+        ["{continue}"]  = false,
+        ["{shuffle}"]  = false,
+        ["{repeat}"]  = false,
+    }
+
+    -- Fallback to CMUS defaults
+    local host = warg and (warg.host or warg[1]) or
+		os.getenv("XDG_RUNTIME_DIR") .. "/cmus-socket"
+
+    -- Get data from CMUS server
+    local f = io.popen(string.format("cmus-remote --query --server %s", host))
+
+    for line in f:lines() do
+        for module, value in string.gmatch(line, "([%w]+) (.*)$") do
+            if module == "file" then
+                cmus_state["{"..module.."}"] = helpers.escape(value)
+            elseif module == "duration" then
+                cmus_state["{"..module.."}"] = tonumber(value)
+            elseif module == "status" then
+                cmus_state["{"..module.."}"] = value
+            else
+                for k, v in string.gmatch(value, "([%w]+) (.*)$") do
+                    if module == "tag" then
+                        if k == "title" or k == "artist" then
+							cmus_state["{"..k.."}"] = helpers.escape(v)
+                        end
+                    elseif module == "set" then
+                        if k == "continue" or k == "shuffle" or k == "repeat" then
+							cmus_state["{"..k.."}"] = v == "true"
+                        end
+                    end
+                end
+            end
+        end
+    end
+    f:close()
+
+    return cmus_state
+end
+-- }}}
+
+return setmetatable(cmus_all, { __call = function(_, ...) return worker(...) end })


### PR DESCRIPTION
I wrote this platform independent widget for `cmus`, mostly based on the `mpd` widget.
Also fixed some markup issues with the contrib/README in the same commit

Tested on Fedora 26
```
awesome v4.2 (Human after all)
 • Compiled against Lua 5.3.4 (running with Lua 5.3)
 • D-Bus support: ✔
 • execinfo support: ✔
 • xcb-randr version: 1.5
 • LGI version: 0.9.2
```