### PR TITLE
Data caching fixes

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -79,8 +79,8 @@ local function update(widget, reg, disablecache)
 
     -- Check for cached output newer than the last update
     local c = widget_cache[reg.wtype]
-    if c and c.time and c.data and t < c.time+reg.timer and not disablecache then
         return update_value(format_data(c.data))
+    if c and t < c.time + reg.timer and not disablecache then
     elseif reg.wtype then
         if type(reg.wtype) == "table" and reg.wtype.async then
             if not reg.lock then
@@ -238,7 +238,7 @@ end
 function vicious.cache(wtype)
     if wtype ~= nil then
         if widget_cache[wtype] == nil then
-            widget_cache[wtype] = {}
+            widget_cache[wtype] = { data = nil, time = 0 }
         end
     end
 end

--- a/init.lua
+++ b/init.lua
@@ -158,24 +158,18 @@ end
 -- {{{ Global functions
 -- {{{ Register a widget
 function vicious.register(widget, wtype, format, timer, warg)
-    local widget = widget
     local reg = {
         -- Set properties
         wtype  = wtype,
         lock   = false,
         format = format,
-        timer  = timer,
+        timer  = timer or 2,
         warg   = warg,
         widget = widget,
     }
     -- Set functions
-    reg.update = function ()
+    function reg.update()
         update(widget, reg)
-    end
-
-    -- Default to 2s timer
-    if reg.timer == nil then
-        reg.timer = 2
     end
 
     -- Register a reg object


### PR DESCRIPTION
Problem fixed by the pull request:
Vicious cache held values returned from format_data() instead of the data itself, so when many widgets were using the same wtype with other `format` string or function, they didn't work correctly (returning only first cached formatted string)

Changes include:
* caching raw worker data first, then updating values for the widgets
* Small readability changes in the vicious.register
* initial data set for timer (so c.time and c.data is always available and is updated since the first update due to initial time=0 value)

Backward compatibility preserved. 