### PR TITLE
FreeBSD memory widgets bugfixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,10 @@ Supported platforms: Linux, FreeBSD.
     total system memory, 4th as free memory, 5th as swap usage in percent, 6th
     as swap usage, 7th as total system swap, 8th as free swap and 9th as
     memory usage with buffers and cache
-  * FreeBSD: see above, but there are two more values: the 9th value is wired memory
-    in percent and the 10th value giving wired memory
+  * FreeBSD: see above, but there are four more values: the 9th value is wired memory
+    in percent, the 10th value is wired memory. The 11th and 12th value return
+    'not freeable memory' (basically active+inactive+wired) in percent and megabytes,
+    respectively.
 
 **vicious.widgets.mpd**
 
@@ -804,8 +806,8 @@ Format functions can be used as well:
             naughty.notify({ title = "Battery indicator",
                              text = vicious.call(vicious.widgets.bat, function(widget, args)
                                  return string.format("%s: %10sh\n%s: %14d%%\n%s: %12dW",
-                                                      "Remaining time", args[3], 
-                                                      "Wear level", args[4], 
+                                                      "Remaining time", args[3],
+                                                      "Wear level", args[4],
                                                       "Present rate", args[5])
                              end, "0") })
         end)

--- a/README.md
+++ b/README.md
@@ -323,9 +323,8 @@ Supported platforms: Linux, FreeBSD.
     total system memory, 4th as free memory, 5th as swap usage in percent, 6th
     as swap usage, 7th as total system swap, 8th as free swap and 9th as
     memory usage with buffers and cache
-  * FreeBSD: see above, but 10th value as memory usage with buffers and cache
-    as percent and 11th value as wired memory (memory used by kernel) is
-    reported
+  * FreeBSD: see above, but 9th value is not returned (always `-1`) and there
+    is a 10th value giving wired memory
 
 **vicious.widgets.mpd**
 

--- a/README.md
+++ b/README.md
@@ -323,8 +323,8 @@ Supported platforms: Linux, FreeBSD.
     total system memory, 4th as free memory, 5th as swap usage in percent, 6th
     as swap usage, 7th as total system swap, 8th as free swap and 9th as
     memory usage with buffers and cache
-  * FreeBSD: see above, but 9th value is not returned (always `-1`) and there
-    is a 10th value giving wired memory
+  * FreeBSD: see above, but there are two more values: the 9th value is wired memory
+    in percent and the 10th value giving wired memory
 
 **vicious.widgets.mpd**
 

--- a/widgets/bat_freebsd.lua
+++ b/widgets/bat_freebsd.lua
@@ -30,6 +30,8 @@ local function worker(format, warg)
         state =  "↯"
     elseif bat_info["State"] == "charging" then
         state = "+"
+    elseif bat_info["State"] == "critical charging" then
+        state = "+"
     elseif bat_info["State"] == "discharging" then
         state = "-"
     else

--- a/widgets/mem_freebsd.lua
+++ b/widgets/mem_freebsd.lua
@@ -16,6 +16,7 @@ local function worker(format)
     local vm_stats = helpers.sysctl_table("vm.stats.vm")
     local _mem = { buf = {}, total = nil }
 
+    -- Get memory space in bytes
     _mem.total = tonumber(vm_stats.v_page_count) * pagesize
     _mem.buf.f = tonumber(vm_stats.v_free_count) * pagesize
     _mem.buf.a = tonumber(vm_stats.v_active_count) * pagesize
@@ -23,35 +24,33 @@ local function worker(format)
     _mem.buf.c = tonumber(vm_stats.v_cache_count) * pagesize
     _mem.buf.w = tonumber(vm_stats.v_wire_count) * pagesize
 
-    -- rework into Megabytes
-    _mem.total = math.floor(_mem.total/(1024*1024))
-    _mem.buf.f = math.floor(_mem.buf.f/(1024*1024))
-    _mem.buf.a = math.floor(_mem.buf.a/(1024*1024))
-    _mem.buf.i = math.floor(_mem.buf.i/(1024*1024))
-    _mem.buf.c = math.floor(_mem.buf.c/(1024*1024))
-    _mem.buf.w = math.floor(_mem.buf.w/(1024*1024))
+    -- Rework into megabytes
+    _mem.total = math.floor(_mem.total/1048576)
+    _mem.buf.f = math.floor(_mem.buf.f/1048576)
+    _mem.buf.a = math.floor(_mem.buf.a/1048576)
+    _mem.buf.i = math.floor(_mem.buf.i/1048576)
+    _mem.buf.c = math.floor(_mem.buf.c/1048576)
+    _mem.buf.w = math.floor(_mem.buf.w/1048576)
 
     -- Calculate memory percentage
-    _mem.free  = _mem.buf.f + _mem.buf.c
-    _mem.inuse = _mem.buf.a + _mem.buf.i
+    _mem.free  = _mem.buf.f + _mem.buf.c + _mem.buf.i
+    _mem.inuse = _mem.total - _mem.free
     _mem.wire  = _mem.buf.w
-    _mem.bcuse = _mem.total - _mem.buf.f
     _mem.usep  = math.floor(_mem.inuse / _mem.total * 100)
     _mem.inusep= math.floor(_mem.inuse / _mem.total * 100)
-    _mem.buffp = math.floor(_mem.bcuse / _mem.total * 100)
-    _mem.wirep = math.floor(_mem.wire /  _mem.total * 100)
 
     -- Get swap states
-    local vm = helpers.sysctl_table("vm")
+    local vm_swap_total = tonumber(helpers.sysctl("vm.swap_total"))
+    local vm_swap_enabled = tonumber(helpers.sysctl("vm.swap_enabled"))
     local _swp = { buf = {}, total = nil }
     
-    if tonumber(vm.swap_enabled) == 1 and tonumber(vm.swap_total) > 0 then
-        -- Get swap space
-        _swp.total = tonumber(vm.swap_total)
+    if vm_swap_enabled == 1 and vm_swap_total > 0 then
+        -- Get swap space in bytes
+        _swp.total = vm_swap_total
         _swp.buf.f = _swp.total - tonumber(vm_stats.v_swapin)
         -- Rework into megabytes
-        _swp.total = math.floor(_swp.total/(1024*1024))
-        _swp.buf.f = math.floor(_swp.buf.f/(1024*1024))
+        _swp.total = math.floor(_swp.total/1048576)
+        _swp.buf.f = math.floor(_swp.buf.f/1048576)
         -- Calculate percentage
         _swp.inuse = _swp.total - _swp.buf.f
         _swp.usep  = math.floor(_swp.inuse / _swp.total * 100)
@@ -64,7 +63,7 @@ local function worker(format)
 
     return { _mem.usep,  _mem.inuse, _mem.total, _mem.free,
              _swp.usep,  _swp.inuse, _swp.total, _swp.buf.f,
-             _mem.bcuse, _mem.buffp, _mem.wirep }
+             -1, _mem.wire }
 end
 
 return setmetatable(mem_freebsd, { __call = function(_, ...) return worker(...) end })

--- a/widgets/mem_freebsd.lua
+++ b/widgets/mem_freebsd.lua
@@ -18,32 +18,31 @@ local function worker(format)
 
     -- Get memory space in bytes
     _mem.total = tonumber(vm_stats.v_page_count) * pagesize
-    _mem.buf.f = tonumber(vm_stats.v_free_count) * pagesize
-    _mem.buf.a = tonumber(vm_stats.v_active_count) * pagesize
-    _mem.buf.i = tonumber(vm_stats.v_inactive_count) * pagesize
-    _mem.buf.c = tonumber(vm_stats.v_cache_count) * pagesize
-    _mem.buf.w = tonumber(vm_stats.v_wire_count) * pagesize
+    _mem.buf.free = tonumber(vm_stats.v_free_count) * pagesize
+    _mem.buf.laundry = tonumber(vm_stats.v_laundry_count) * pagesize
+    _mem.buf.cache = tonumber(vm_stats.v_cache_count) * pagesize
+    _mem.buf.wired = tonumber(vm_stats.v_wire_count) * pagesize
 
     -- Rework into megabytes
     _mem.total = math.floor(_mem.total/1048576)
-    _mem.buf.f = math.floor(_mem.buf.f/1048576)
-    _mem.buf.a = math.floor(_mem.buf.a/1048576)
-    _mem.buf.i = math.floor(_mem.buf.i/1048576)
-    _mem.buf.c = math.floor(_mem.buf.c/1048576)
-    _mem.buf.w = math.floor(_mem.buf.w/1048576)
+    _mem.buf.free = math.floor(_mem.buf.free/1048576)
+    _mem.buf.laundry = math.floor(_mem.buf.laundry/1048576)
+    _mem.buf.cache = math.floor(_mem.buf.cache/1048576)
+    _mem.buf.wired = math.floor(_mem.buf.wired/1048576)
 
     -- Calculate memory percentage
-    _mem.free  = _mem.buf.f + _mem.buf.c + _mem.buf.i
+    _mem.free  = _mem.buf.free + _mem.buf.cache + _mem.buf.laundry
+    -- used memory basically consists of active+inactive+wired
     _mem.inuse = _mem.total - _mem.free
-    _mem.wire  = _mem.buf.w
+    _mem.wire  = _mem.buf.wired
     _mem.usep  = math.floor(_mem.inuse / _mem.total * 100)
-    _mem.inusep= math.floor(_mem.inuse / _mem.total * 100)
+    _mem.wirep = math.floor(_mem.wire / _mem.total * 100)
 
     -- Get swap states
     local vm_swap_total = tonumber(helpers.sysctl("vm.swap_total"))
     local vm_swap_enabled = tonumber(helpers.sysctl("vm.swap_enabled"))
     local _swp = { buf = {}, total = nil }
-    
+
     if vm_swap_enabled == 1 and vm_swap_total > 0 then
         -- Get swap space in bytes
         _swp.total = vm_swap_total
@@ -63,7 +62,7 @@ local function worker(format)
 
     return { _mem.usep,  _mem.inuse, _mem.total, _mem.free,
              _swp.usep,  _swp.inuse, _swp.total, _swp.buf.f,
-             -1, _mem.wire }
+             _mem.wirep, _mem.wire }
 end
 
 return setmetatable(mem_freebsd, { __call = function(_, ...) return worker(...) end })


### PR DESCRIPTION
As discussed in #55, here is the pull request.

#### memory
* corrects calculations for amount of used and free memory 
* improves the returned table by re-arranging the four FreeBSD specific values.

  table entry | value
  --- | ---
  9 | wired memory in percent 
  10 | wired memory in megabytes
  11 | not freeable memory in percent
  12 | not freeable memory in megabytes

* removes unnecessary variables and calculations on those

#### battery
* adds "critical charging" state