### PR TITLE
Use MemAvailable for mem.free

### DIFF
--- a/widgets/mem_linux.lua
+++ b/widgets/mem_linux.lua
@@ -26,6 +26,7 @@ local function worker(format)
         for k, v in string.gmatch(line, "([%a]+):[%s]+([%d]+).+") do
             if     k == "MemTotal"  then _mem.total = math.floor(v/1024)
             elseif k == "MemFree"   then _mem.buf.f = math.floor(v/1024)
+            elseif k == "MemAvailable" then _mem.buf.a = math.floor(v/1024)
             elseif k == "Buffers"   then _mem.buf.b = math.floor(v/1024)
             elseif k == "Cached"    then _mem.buf.c = math.floor(v/1024)
             elseif k == "SwapTotal" then _mem.swp.t = math.floor(v/1024)
@@ -35,7 +36,7 @@ local function worker(format)
     end
 
     -- Calculate memory percentage
-    _mem.free  = _mem.buf.f + _mem.buf.b + _mem.buf.c
+    _mem.free  = _mem.buf.a
     _mem.inuse = _mem.total - _mem.free
     _mem.bcuse = _mem.total - _mem.buf.f
     _mem.usep  = math.floor(_mem.inuse / _mem.total * 100)


### PR DESCRIPTION
The current method of calculating the amount of free memory is
incorrect. The linux kernel provides a method of getting this value,
MemAvailable, which we can simply use directly.

See [this commit for more information](https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=34e431b0ae398fc54ea69ff85ec700722c9da773).

Let me know if you think this shouldn't be applied where it is currently. For me, this changes the value displayed dramatically, but it's much more correct and what I expected when installing this package.